### PR TITLE
Refactor database connection response and test setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,8 +118,6 @@ def test_db():
         inspector = inspect(engine)
         tables = inspector.get_table_names()
         return {
-            "status": "success",
-            "result": 1,
             "message": "Database connection successful",
             "tables": tables
         }

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -70,9 +70,13 @@ def test_db_connection(client):
     """Test de connexion à la base de données."""
     response = client.get("/test-db")
     assert response.status_code == 200
-    assert "status" in response.json()
-    assert response.json()["status"] == "success"
-    assert response.json()["result"] == 1
+    data = response.json()
+    assert "message" in data
+    assert data["message"] == "Database connection successful"
+    assert "tables" in data
+    # Vérifier que les tables requises sont présentes
+    required_tables = {"epidemic", "data_source", "localisation", "daily_stats", "overall_stats"}
+    assert required_tables.issubset(set(data["tables"]))
 
 def test_etl_data_integrity(db_session):
     """Test de l'intégrité des données ETL."""


### PR DESCRIPTION
- Removed the "status" and "result" fields from the database connection response in main.py, simplifying the output to focus on the message and tables.
- Updated conftest.py to create a single test engine and session for improved efficiency and clarity in tests.
- Modified test_main.py to assert the new response structure and verify the presence of required tables in the database connection test.