### PR TITLE
Refactor backend Dockerfile for improved startup process

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,9 +4,6 @@ FROM python:3.10-slim
 # Définir le dossier de travail
 WORKDIR /app
 
-# Installer wget (nécessaire pour le script d'attente)
-RUN apt-get update && apt-get install -y wget
-
 # Installer les dépendances système
 RUN apt-get update && apt-get install -y \
     gcc \
@@ -20,24 +17,14 @@ COPY requirements.txt .
 # Installer les dépendances 
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Créer un script d'attente pour MySQL
-RUN wget -O /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
-    && chmod +x /wait-for-it.sh
-
 # Copier le code source de l'API
 COPY . .
 
 # Ajouter le répertoire racine au PYTHONPATH
 ENV PYTHONPATH=/app
 
-# Créer un script de démarrage
-RUN echo '#!/bin/bash\n\
-/wait-for-it.sh $DB_HOST:$DB_PORT -t 60\n\
-uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload\n\
-' > /start.sh && chmod +x /start.sh
-
 # Exposer le port de l'API
 EXPOSE 8000
 
-# Commande de démarrage
-CMD ["/start.sh"]
+# Commande de démarrage directement avec Uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
- Removed wget installation and the wait-for-it script.
- Updated the CMD instruction to directly run Uvicorn for starting the API, simplifying the startup process.