### PR TITLE
Update Dockerfile to change Uvicorn app path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,4 +27,4 @@ ENV PYTHONPATH=/app
 EXPOSE 8000
 
 # Commande de démarrage directement avec Uvicorn
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
- Modified the CMD instruction in the Dockerfile to specify the app path as "app.main:app" for improved clarity in the startup command.