### PR TITLE
Update CI workflow to specify backend deployment to Railway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,9 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway
+      - name: Deploy backend to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           cd backend
-          railway up --service "analyseit-backend"
+          railway up --service AnaliseIT-Backend


### PR DESCRIPTION
- Renamed the deployment step to "Deploy backend to Railway" for clarity.
- Updated the service name in the deployment command to "AnaliseIT-Backend".