### PR TITLE
Update API backend URL configuration to use environment variable

### DIFF
--- a/frontend/app/api/v1/admin/init-db/route.ts
+++ b/frontend/app/api/v1/admin/init-db/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
     
     // Appel à l'API backend
     // Attention : en environnement Docker, utilisez le hostname du service backend, pas localhost
-    const backendUrl = 'http://backend:8000';
+    const backendUrl = 'process.env.NEXT_PUBLIC_API_URL';
     console.log(`Tentative de connexion au backend à l'URL: ${backendUrl}`);
     
     const response = await fetch(`${backendUrl}/api/v1/admin/init-db?reset=${reset}`, {

--- a/frontend/app/api/v1/admin/run-etl/route.ts
+++ b/frontend/app/api/v1/admin/run-etl/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
     
     // Appel à l'API backend
     // Attention : en environnement Docker, utilisez le hostname du service backend, pas localhost
-    const backendUrl = 'http://backend:8000';
+    const backendUrl = 'process.env.NEXT_PUBLIC_API_URL';
     console.log(`Tentative de connexion au backend à l'URL: ${backendUrl}`);
     
     const response = await fetch(`${backendUrl}/api/v1/admin/run-etl?reset=${reset}`, {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
         return [
             {
                 source: '/api/:path*',
-                destination: 'http://backend:8000/api/:path*',
+                destination: process.env.NEXT_PUBLIC_API_URL + '/:path*',
             },
         ]
     },


### PR DESCRIPTION
- Changed hardcoded backend URL to utilize NEXT_PUBLIC_API_URL for improved flexibility in deployment environments.
- Ensured consistency across API routes by updating the backend URL reference in init-db and run-etl route files.