### PR TITLE
Update API base URL configuration to remove hardcoded localhost value

### DIFF
--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -28,7 +28,7 @@ declare global {
 
 // Configuration de base d'Axios
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000",
+  baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
- Adjusted the baseURL in the Axios configuration to exclusively use the NEXT_PUBLIC_BACKEND_URL environment variable for improved deployment flexibility.